### PR TITLE
Null check before using get_class()

### DIFF
--- a/src/SnapshotsManager.php
+++ b/src/SnapshotsManager.php
@@ -22,7 +22,7 @@ class SnapshotsManager
      */
     public static function setSuite($suite)
     {
-        if (get_class(static::$suite) !== get_class($suite)) {
+        if (static::$suite !== null && get_class(static::$suite) !== get_class($suite)) {
             static::$assertionsInTest = [];
         }
 


### PR DESCRIPTION
As of PHP 7.2, `get_class()` parameter can not be null.

This PR adds a simple null check before using `get_class()`.